### PR TITLE
Feat/imgController

### DIFF
--- a/src/main/java/com/ohdogcat/util/FtpImgLoaderUtil.java
+++ b/src/main/java/com/ohdogcat/util/FtpImgLoaderUtil.java
@@ -32,6 +32,11 @@ public class FtpImgLoaderUtil {
 
     public FtpImgLoaderUtil() {
         ftpClient = new FTPClient();
+        try {
+            boolean result = connect();
+        } catch (IOException e) {
+            log.error("FTP 연결 실패, {}", e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/com/ohdogcat/util/FtpImgLoaderUtil.java
+++ b/src/main/java/com/ohdogcat/util/FtpImgLoaderUtil.java
@@ -32,11 +32,6 @@ public class FtpImgLoaderUtil {
 
     public FtpImgLoaderUtil() {
         ftpClient = new FTPClient();
-        try {
-            boolean result = connect();
-        } catch (IOException e) {
-            log.error("FTP 연결 실패, {}", e.getMessage());
-        }
     }
 
     /**
@@ -48,6 +43,8 @@ public class FtpImgLoaderUtil {
      * @throws IOException 아마자 업로드 시 문제 발생 시 IOException qkftod
      */
     public String upload(MultipartFile file, HttpServletRequest req) throws IOException {
+
+        connect();
 
         String result = null;
 
@@ -67,6 +64,7 @@ public class FtpImgLoaderUtil {
             result = String.join("/", filePath);
         }
 
+        disconnect();
         return result;
     }
 
@@ -79,8 +77,8 @@ public class FtpImgLoaderUtil {
      * @throws IOException
      */
     public Resource download(String imgUrl) throws IOException {
+        connect();
         setFtpClientConfig();
-
         InputStream imgStream = ftpClient.retrieveFileStream(imgUrl);
         byte[] result = IOUtils.toByteArray(imgStream);
 
@@ -91,6 +89,7 @@ public class FtpImgLoaderUtil {
 
         Resource resource = new ByteArrayResource(result);
         imgStream.close();
+        disconnect();
         return resource;
     }
 
@@ -100,13 +99,13 @@ public class FtpImgLoaderUtil {
      * @param imgUrl 삭제할 파일의 경로
      * @return 성공 시 true, 실패 시 false 반환
      */
-    public boolean delete(String imgUrl) {
+    public boolean delete(String imgUrl) throws IOException {
         boolean result = false;
-        try {
-            result = ftpClient.deleteFile(imgUrl);
-        } catch (IOException e) {
-            return result;
-        }
+
+        connect();
+        result = ftpClient.deleteFile(imgUrl);
+        disconnect();
+
         return result;
     }
 

--- a/src/main/java/com/ohdogcat/web/HomeController.java
+++ b/src/main/java/com/ohdogcat/web/HomeController.java
@@ -1,38 +1,35 @@
 package com.ohdogcat.web;
 
+import com.ohdogcat.dto.product.ProductPetTypeDto;
+import com.ohdogcat.service.ProductService;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-
-import com.ohdogcat.dto.product.ProductPetTypeDto;
-import com.ohdogcat.service.ProductService;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Controller
 @RequiredArgsConstructor
 public class HomeController {
-	private final ProductService productService;
-	
-	@GetMapping("/")
-	public String home(Model model) {
-		log.debug("home()");
-		
-		// 강아지 & 고양이 신상품 및 베스트 상품 각각 상위 8개 목록
-		List<ProductPetTypeDto> dogNew = productService.readDogOrderByNew();
-		List<ProductPetTypeDto> dogBest = productService.readDogOrderByBest();
-		List<ProductPetTypeDto> catNew = productService.readCatOrderByNew();
-		List<ProductPetTypeDto> catBest = productService.readCatOrderByBest();
-		
-		model.addAttribute("dogNew", dogNew);
-		model.addAttribute("dogBest", dogBest);
-		model.addAttribute("catNew", catNew);
-		model.addAttribute("catBest", catBest);
-		
-		return "home";
-	}
+    private final ProductService productService;
+
+    @GetMapping("/")
+    public String home(Model model) {
+        log.debug("home()");
+
+        // 강아지 & 고양이 신상품 및 베스트 상품 각각 상위 8개 목록
+        List<ProductPetTypeDto> dogNew = productService.readDogOrderByNew();
+        List<ProductPetTypeDto> dogBest = productService.readDogOrderByBest();
+        List<ProductPetTypeDto> catNew = productService.readCatOrderByNew();
+        List<ProductPetTypeDto> catBest = productService.readCatOrderByBest();
+
+        model.addAttribute("dogNew", dogNew);
+        model.addAttribute("dogBest", dogBest);
+        model.addAttribute("catNew", catNew);
+        model.addAttribute("catBest", catBest);
+
+        return "home";
+    }
 }

--- a/src/main/java/com/ohdogcat/web/ImageRestController.java
+++ b/src/main/java/com/ohdogcat/web/ImageRestController.java
@@ -1,8 +1,10 @@
 package com.ohdogcat.web;
 
 import com.ohdogcat.util.FtpImgLoaderUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/image")
@@ -19,8 +22,11 @@ public class ImageRestController {
 
     private final FtpImgLoaderUtil imgUploader;
 
-    @GetMapping("/")
-    public ResponseEntity<Resource> getImage(@RequestParam String imgUrl) throws IOException {
+    @GetMapping("")
+    public ResponseEntity<Resource> getImage(@RequestParam String imgUrl, HttpServletRequest req)
+        throws IOException {
+        log.debug("getImage(imgUrl={}", imgUrl);
+
         Resource resource = imgUploader.download(imgUrl);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);

--- a/src/main/java/com/ohdogcat/web/ImageRestController.java
+++ b/src/main/java/com/ohdogcat/web/ImageRestController.java
@@ -1,0 +1,30 @@
+package com.ohdogcat.web;
+
+import com.ohdogcat.util.FtpImgLoaderUtil;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/image")
+public class ImageRestController {
+
+    private final FtpImgLoaderUtil imgUploader;
+
+    @GetMapping("/")
+    public ResponseEntity<Resource> getImage(@RequestParam String imgUrl) throws IOException {
+        Resource resource = imgUploader.download(imgUrl);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        return ResponseEntity.ok().headers(headers).body(resource);
+    }
+
+}

--- a/src/main/webapp/WEB-INF/application-context.xml
+++ b/src/main/webapp/WEB-INF/application-context.xml
@@ -34,6 +34,8 @@
       value="classpath:mybatis-config.xml"/>
   </bean>
 
+  <bean id="fileUtil" class="com.ohdogcat.util.FtpImgLoaderUtil"/>
+
 
   <!-- MyBatis 프레임워크에서 생성하고 관리하는 빈(bean)들을 base-package와 그 하위 패키지에서 찾음. PostDao,
     UserDao 인터페이스들을 작성하는 패키지. -->

--- a/src/main/webapp/WEB-INF/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/servlet-context.xml
@@ -19,8 +19,19 @@
           </list>
         </property>
       </bean>
+
+      <bean class="org.springframework.http.converter.ByteArrayHttpMessageConverter">
+        <property name="supportedMediaTypes">
+          <list>
+            <value>application/octet-stream</value>
+          </list>
+        </property>
+      </bean>
+
     </mvc:message-converters>
   </mvc:annotation-driven>
+
+
 
   <!-- Spring MVC에서 dispatcherServlet이 처리하지 않는 정적 요청에 필요한 파일들 (image, css,
     javascript, ...)이 있는 폴더 위치를 설정. 정적 리소스(이미지, CSS, JS)의 폴더를 /webapp/static/


### PR DESCRIPTION
## 구현 목적
API - GET /image 
쿼리스트링 키: imgUrl, value 업로드 시 반환 받은 imgPath값을 보내면 해당 경로 내의 파일 반환

### FTPClient 수정 포함
- connect 를 FTPClient가 생성될 때만 하는 방식을 사용하니 첫 요청에는 응답으로 사진 이미지를 보내지만 두번째부터는 에러를 반환했다.
- 원인은 규명하지 못했으나 이전 테스트 시 사용했던 것처럼 FTP 유틸을 다운로드, 업로드 요청이 들어올 때마다 connect하고 disconnect하는 방식으로 변경했다.
- 우선 다음 구현 사항을 해결한 후, 이에 대한 원인을 찾아봐야겠다.