### PR TITLE
fix: 파일 업로더 유틸 요청 여러번 보낼 시 이미지 로딩 안되는 문제 해결

### DIFF
--- a/src/main/java/com/ohdogcat/util/FtpUploaderUtil.java
+++ b/src/main/java/com/ohdogcat/util/FtpUploaderUtil.java
@@ -1,0 +1,11 @@
+package com.ohdogcat.util;
+
+import java.io.IOException;
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FtpUploaderUtil {
+    String upload(MultipartFile file, String servletPath) throws IOException;
+    Resource download(String imgUrl) throws IOException;
+    boolean delete(String imgUrl) throws IOException;
+}

--- a/src/main/java/com/ohdogcat/web/ImageRestController.java
+++ b/src/main/java/com/ohdogcat/web/ImageRestController.java
@@ -1,6 +1,6 @@
 package com.ohdogcat.web;
 
-import com.ohdogcat.util.FtpImgLoaderUtil;
+import com.ohdogcat.util.FtpUploaderUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/image")
 public class ImageRestController {
 
-    private final FtpImgLoaderUtil imgUploader;
+    private final FtpUploaderUtil imgUploader;
 
     @GetMapping("")
     public ResponseEntity<Resource> getImage(@RequestParam String imgUrl, HttpServletRequest req)

--- a/src/main/java/com/ohdogcat/web/PetController.java
+++ b/src/main/java/com/ohdogcat/web/PetController.java
@@ -1,5 +1,6 @@
 package com.ohdogcat.web;
 
+import com.ohdogcat.util.FtpUploaderUtil;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.stereotype.Controller;
@@ -28,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PetController {
 
   private final PetService petService;
-  private final FtpImgLoaderUtil ftpImgLoaderUtil;
+  private final FtpUploaderUtil ftpImgLoaderUtil;
 
   @GetMapping("/pet")
   public String myPet(HttpSession session, Model model) {

--- a/src/main/webapp/WEB-INF/application-context.xml
+++ b/src/main/webapp/WEB-INF/application-context.xml
@@ -39,7 +39,7 @@ http://www.springframework.org/schema/tx
     <constructor-arg ref="hikariConfig"/>
   </bean>
 
-  <bean id="fileUtil" class="com.ohdogcat.util.FtpImgLoaderUtil"/>
+  <bean id="fileUtil" class="com.ohdogcat.util.FtpImgLoaderUtil2"/>
 
 
   <!-- MyBatis 프레임워크에서 생성하고 관리하는 빈(bean)들을 base-package와 그 하위 패키지에서 찾음. PostDao,


### PR DESCRIPTION
## 해결 사항
1. 문제 : 파일 업로더 유틸을 활용해서 이미지를 불러오는 `ImgController`에 요청이 중첩되면, 유틸에서 멤버로 사용하는 FtpClient객체가 Connect()와 Disconnect()가 순서대로 되는 것이 아니라 중첩된 요청의 이미지를 불러오기 전에 Disconnect()되는 문제가 있었다. Connect()와 Disconnect()를 서버가 생성될 때와 종료될 때 한 번씩만 호출하는 방법도 사용하였으나, 두번째 요청에서부터는 데이터가 로딩되지 않는 문제가 있었다.
 - 해결 : 각 요청마다 FTPClient 인스턴스를 따로 생성하여 각각의 인스턴스가 하나의 파일을 불러오도록 했다.


## 문제
- 프로젝트의 경우, 해결이 우선시 되어 위의 해결 방법으로 우선 구현되었으나, 실제 서비스에서 위와 같은 구현을 한다면 서버에 부하가 많이 걸릴 것이다. 메모리를 많이 사용하기 때문에 문제가 있을 수밖에 없다. ImgController를 사용하지 않고 개별 이미지 요청이 아니라 페이지 요청시의 buffer 데이터를 직접 불러온다면 해결할 수 있을 것 같지만 Util 이외의 처리를 다양하게 해야한다는 문제점이 있다.
- HTTP 프로토콜 이외 FTP에 대해 더 명확히 공부하고, JAVA와 Spring에서 이를 처리하는 객체들을 다양하게 알아보아야겠다.